### PR TITLE
fix: App.tsx에 safeAreaProvider 적용

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,12 +10,15 @@ import React from 'react';
 import { Text } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import RootStackNavigator from './src/navigators/RootStackNavigator';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 function App() {
   return (
-    <NavigationContainer>
-      <RootStackNavigator />
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <RootStackNavigator />
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 


### PR DESCRIPTION
- `App.tsx`에 `SafeAreaProvider`를 감싸주었습니다.
- @jwoo9928 지난 번에 물어봐 주신 react naive의 safe-area-view와 react-native-safe-area-context의 차이를 찾아보다가 이거를 적용해 줘야 한다고 해서 적용해 주었습니다. [(출처)](https://stackoverflow.com/a/61887662/15458307)  


### react naive의 safe-area-view와 react-native-safe-area-context의 차이

- react-native의 safeareaview보다 약간의 부가적인 기능을 제공하고, react-navigation(v5)를 사용하는 경우 더 잘 맞는다고 합니다. (저희는 react-navigation-v6를 쓰는데 v6에도 적용되는지는 모르겠네요 찾게 된다면 말씀해 주세요! ㅎㅎ)
<img width="662" alt="image" src="https://user-images.githubusercontent.com/59302192/179199604-a51b61f6-b241-47f2-8c49-f6d2401e68f5.png">
<img width="649" alt="image" src="https://user-images.githubusercontent.com/59302192/179199793-f9ea8749-f1f5-4b69-aa2c-2c213c7a61b9.png">
<img width="674" alt="image" src="https://user-images.githubusercontent.com/59302192/179199848-c98325c1-0b32-408a-a868-a7e1795be5ca.png">
